### PR TITLE
Only launch kernel once to collect metrics

### DIFF
--- a/include/tally/cuda_launch.h
+++ b/include/tally/cuda_launch.h
@@ -230,7 +230,7 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, const CudaLaunchConfig& config);
     
-    CUresult launch(const void *, dim3, dim3, void **, size_t, cudaStream_t, PTBArgs *ptb_args, uint32_t *curr_idx_arr=nullptr, bool run_profile=false, float *elapsed_time_ms=nullptr);
+    CUresult launch(const void *, dim3, dim3, void **, size_t, cudaStream_t, PTBArgs *ptb_args, uint32_t *curr_idx_arr=nullptr);
     CUresult repeat_launch(const void *, dim3, dim3, void **, size_t, cudaStream_t, float dur_seconds, PTBArgs *ptb_args, uint32_t *curr_idx_arr=nullptr, float *time_ms=nullptr, float *iters=nullptr, int32_t max_count=-1);
 };
 
@@ -277,6 +277,11 @@ struct std::hash<CudaLaunchCallConfigPair>
                      std::hash<CudaLaunchCallConfig>()(k.call_config_2);
         return _hash;
     }
+};
+
+struct TempKernelProfileMetrics {
+    float avg_latency_ms = 0.;
+    uint32_t count = 0;
 };
 
 struct KernelProfileMetrics {

--- a/include/tally/env.h
+++ b/include/tally/env.h
@@ -25,6 +25,9 @@ static uint32_t FATBIN_MAGIC_NUMBER = 3126193488;
 // These can be tuned
 static uint32_t PTB_MAX_NUM_THREADS_PER_SM = 1024;
 
+// number of times to run a kernel to get performance metrics
+static uint32_t KERNEL_PROFILE_ITERATIONS = 30;
+
 // Time share Threshold
 static float TIME_SHARE_THRESHOLD = 1.f;
 static float USE_PTB_THRESHOLD = 0.5f;

--- a/include/tally/generated/server.h
+++ b/include/tally/generated/server.h
@@ -143,8 +143,9 @@ public:
     std::unordered_map<CudaLaunchCallPair, std::unordered_map<CudaLaunchCallConfigPair, CudaLaunchCallConfigPairResult>> kernel_pair_perf_map;
 	std::unordered_map<CudaLaunchCallPair, CudaLaunchCallConfigPairResult> kernel_pair_best_config_map;
 
-	// Set and Get performance cache
+	void launch_and_measure_kernel(KernelLaunchWrapper &kernel_wrapper, int32_t client_id, std::vector<CudaLaunchConfig> &configs);
 
+	// Set and Get performance cache
 	CudaLaunchCallConfigResult get_single_kernel_perf(CudaLaunchCall &launch_call, CudaLaunchConfig launch_config, bool *found);
 	void set_single_kernel_perf(CudaLaunchCall &launch_call, CudaLaunchConfig launch_config, CudaLaunchMetadata meta_data, float norm_speed, float latency, uint32_t iters);
 

--- a/python/tally/preload/client_consts.py
+++ b/python/tally/preload/client_consts.py
@@ -314,8 +314,9 @@ public:
     std::unordered_map<CudaLaunchCallPair, std::unordered_map<CudaLaunchCallConfigPair, CudaLaunchCallConfigPairResult>> kernel_pair_perf_map;
 	std::unordered_map<CudaLaunchCallPair, CudaLaunchCallConfigPairResult> kernel_pair_best_config_map;
 
-	// Set and Get performance cache
+	void launch_and_measure_kernel(KernelLaunchWrapper &kernel_wrapper, int32_t client_id, std::vector<CudaLaunchConfig> &configs);
 
+	// Set and Get performance cache
 	CudaLaunchCallConfigResult get_single_kernel_perf(CudaLaunchCall &launch_call, CudaLaunchConfig launch_config, bool *found);
 	void set_single_kernel_perf(CudaLaunchCall &launch_call, CudaLaunchConfig launch_config, CudaLaunchMetadata meta_data, float norm_speed, float latency, uint32_t iters);
 
@@ -419,7 +420,7 @@ public:
 	std::pair<partial_t, void *> cublasGemmEx_Partial(cublasGemmExArg *);
 	std::pair<partial_t, void *> cublasGemmStridedBatchedEx_Partial(cublasGemmStridedBatchedExArg *);
     std::pair<partial_t, void *> cublasSgemmStridedBatched_Partial(cublasSgemmStridedBatchedArg *__args);
-    
+     
 """
 
 TALLY_SERVER_HEADER_TEMPLATE_BUTTOM = """

--- a/src/tally/cuda_launch.cpp
+++ b/src/tally/cuda_launch.cpp
@@ -237,41 +237,21 @@ CUresult CudaLaunchConfig::repeat_launch(
 
 CUresult CudaLaunchConfig::launch(
     const void *func, dim3  gridDim, dim3  blockDim, void ** args, size_t  sharedMem, cudaStream_t stream,
-    PTBArgs *ptb_args, uint32_t *curr_idx_arr, bool run_profile, float *elapsed_time_ms)
+    PTBArgs *ptb_args, uint32_t *curr_idx_arr)
 {
-    cudaEvent_t _start, _stop;
-
     if (use_original) {
 
-        if (run_profile) {
-            cudaEventCreate(&_start);
-            cudaEventCreate(&_stop);
-            cudaStreamSynchronize(stream);
-
-            cudaEventRecord(_start);
-        }
-
         CUfunction cu_func = TallyServer::server->original_kernel_map[func].func;
-
         assert(cu_func);
 
         auto err = lcuLaunchKernel(cu_func, gridDim.x, gridDim.y, gridDim.z,
                                 blockDim.x, blockDim.y, blockDim.z, sharedMem, stream, args, NULL);
-
-        if (run_profile) {
-            cudaEventRecord(_stop);
-            cudaEventSynchronize(_stop);
-            cudaEventElapsedTime(elapsed_time_ms, _start, _stop);
-            cudaEventDestroy(_start);
-            cudaEventDestroy(_stop);
-        }
 
         return err;
     } else if (use_ptb) {
 
         CUfunction cu_func = TallyServer::server->ptb_kernel_map[func].func;
         size_t num_args = TallyServer::server->ptb_kernel_map[func].num_args;
-
         assert(cu_func);
 
         dim3 PTB_grid_dim;
@@ -290,24 +270,8 @@ CUresult CudaLaunchConfig::launch(
         }
         KernelParams[num_args - 1] = &gridDim;
 
-        if (run_profile) {
-            cudaEventCreate(&_start);
-            cudaEventCreate(&_stop);
-            cudaStreamSynchronize(stream);
-
-            cudaEventRecord(_start);
-        }
-
         auto err = lcuLaunchKernel(cu_func, PTB_grid_dim.x, PTB_grid_dim.y, PTB_grid_dim.z,
                               blockDim.x, blockDim.y, blockDim.z, sharedMem, stream, KernelParams, NULL);
-
-        if (run_profile) {
-            cudaEventRecord(_stop);
-            cudaEventSynchronize(_stop);
-            cudaEventElapsedTime(elapsed_time_ms, _start, _stop);
-            cudaEventDestroy(_start);
-            cudaEventDestroy(_stop);
-        }
 
         return err;
         
@@ -339,24 +303,8 @@ CUresult CudaLaunchConfig::launch(
         KernelParams[num_args - 2] = &global_idx;
         KernelParams[num_args - 1] = &curr_idx_arr;
 
-        if (run_profile) {
-            cudaEventCreate(&_start);
-            cudaEventCreate(&_stop);
-            cudaStreamSynchronize(stream);
-
-            cudaEventRecord(_start);
-        }
-
         auto err = lcuLaunchKernel(cu_func, PTB_grid_dim.x, PTB_grid_dim.y, PTB_grid_dim.z,
                               blockDim.x, blockDim.y, blockDim.z, sharedMem, stream, KernelParams, NULL);
-
-        if (run_profile) {
-            cudaEventRecord(_stop);
-            cudaEventSynchronize(_stop);
-            cudaEventElapsedTime(elapsed_time_ms, _start, _stop);
-            cudaEventDestroy(_start);
-            cudaEventDestroy(_stop);
-        }
 
         return err;
 
@@ -391,24 +339,8 @@ CUresult CudaLaunchConfig::launch(
         KernelParams[num_args - 2] = &retreat;
         KernelParams[num_args - 1] = &curr_idx_arr;
 
-        if (run_profile) {
-            cudaEventCreate(&_start);
-            cudaEventCreate(&_stop);
-            cudaStreamSynchronize(stream);
-
-            cudaEventRecord(_start);
-        }
-
         auto err = lcuLaunchKernel(cu_func, PTB_grid_dim.x, PTB_grid_dim.y, PTB_grid_dim.z,
                               blockDim.x, blockDim.y, blockDim.z, sharedMem, stream, KernelParams, NULL);
-
-        if (run_profile) {
-            cudaEventRecord(_stop);
-            cudaEventSynchronize(_stop);
-            cudaEventElapsedTime(elapsed_time_ms, _start, _stop);
-            cudaEventDestroy(_start);
-            cudaEventDestroy(_stop);
-        }
 
         return err;
 

--- a/src/tally/scheduler/priority.cpp
+++ b/src/tally/scheduler/priority.cpp
@@ -214,8 +214,11 @@ void TallyServer::run_priority_scheduler()
                     auto num_blocks = launch_call.gridDim.x * launch_call.gridDim.y * launch_call.gridDim.z;
 
                     auto preemptive_ptb_configs = CudaLaunchConfig::get_priority_preemptive_configs(threads_per_block, num_blocks);
-                    tune_kernel_launch(kernel_wrapper, client_id, preemptive_ptb_configs);
-                    res = get_single_kernel_best_config(launch_call, &found_in_cache);
+                    launch_and_measure_kernel(kernel_wrapper, client_id, preemptive_ptb_configs);
+
+                    kernel_wrapper.free_args();
+                    client_data.queue_size--;
+                    break;
                 }
 
                 PTBArgs *ptb_args = nullptr;

--- a/src/tally/scheduler/workload_agnostic.cpp
+++ b/src/tally/scheduler/workload_agnostic.cpp
@@ -54,9 +54,9 @@ void TallyServer::run_workload_agnostic_sharing_scheduler()
                         auto num_blocks = launch_call.gridDim.x * launch_call.gridDim.y * launch_call.gridDim.z;
                         auto configs = CudaLaunchConfig::get_workload_agnostic_sharing_configs(threads_per_block, num_blocks);
 
-                        tune_kernel_launch(kernel_wrapper, client_id, configs);
-                        res = get_single_kernel_best_config(launch_call, &found_in_cache);
-                        assert(found_in_cache);
+                        launch_and_measure_kernel(kernel_wrapper, client_id, configs);
+                        client_data.queue_size--;
+                        continue;
                     }
 
                     config = res.config;


### PR DESCRIPTION
Instead of repeatedly launch kernel to collect metrics. Only launch it once. 

This maintains the correctness of the kernels when profiling.